### PR TITLE
Compatibility cleanup

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -10,20 +10,20 @@ import string
 
 # Python 2/3 compatibility
 if sys.version_info[0] >= 3:
-    import configparser
-    import urllib.parse
-    import urllib.request
-    import urllib.error
+    from configparser import ConfigParser, NoOptionError
+    from urllib.parse import urlencode
+    from urllib.error import URLError
+    from urllib.request import Request, build_opener, HTTPCookieProcessor
 
     def form_body(form):
         return str(form).encode('utf-8')
 else:
     # Python 2, import modules with Python 3 names
-    import ConfigParser as configparser
-    import urllib
-    import urllib2
-    urllib.request = urllib.error = urllib2
-    urllib.parse = urllib
+    from ConfigParser import ConfigParser, NoOptionError
+    from urllib import urlencode
+    from urllib2 import URLError
+    from urllib2 import Request, build_opener, HTTPCookieProcessor
+
 
     def form_body(form):
         return str(form)
@@ -102,7 +102,7 @@ class MultiPartForm(object):
 
     def make_request(self, url):
         body = form_body(self)
-        request = urllib.request.Request(url, data=body)
+        request = Request(url, data=body)
         request.add_header('Content-type', self.get_content_type())
         request.add_header('Content-length', len(body))
         return request
@@ -194,8 +194,8 @@ def login(login_url, username, password=None, token=None):
     if token:
         login_args['token'] = token
 
-    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor())
-    opener.open(login_url, urllib.parse.urlencode(login_args).encode('ascii'))
+    opener = build_opener(HTTPCookieProcessor())
+    opener.open(login_url, urlencode(login_args).encode('ascii'))
     return opener
 
 
@@ -209,11 +209,11 @@ def login_from_config(cfg):
     password = token = None
     try:
         password = cfg.get('user', 'password')
-    except configparser.NoOptionError:
+    except NoOptionError:
         pass
     try:
         token = cfg.get('user', 'token')
-    except configparser.NoOptionError:
+    except NoOptionError:
         pass
     if password is None and token is None:
         raise ConfigError('''\
@@ -326,7 +326,7 @@ extension "%s"''' % (ext))
     except ConfigError as exc:
         print(exc)
         sys.exit(1)
-    except urllib.error.URLError as exc:
+    except URLError as exc:
         if hasattr(exc, 'code'):
             print('Login failed.')
             if exc.code == 403:
@@ -347,7 +347,7 @@ extension "%s"''' % (ext))
 
     try:
         result = submit(opener, submit_url, problem, language, files, mainclass, tag)
-    except urllib.error.URLError as exc:
+    except URLError as exc:
         if hasattr(exc, 'code'):
             print('Submission failed.')
             if exc.code == 403:

--- a/submit.py
+++ b/submit.py
@@ -10,7 +10,7 @@ import string
 
 # Python 2/3 compatibility
 if sys.version_info[0] >= 3:
-    from configparser import ConfigParser, NoOptionError
+    import configparser
     from urllib.parse import urlencode
     from urllib.error import URLError
     from urllib.request import Request, build_opener, HTTPCookieProcessor
@@ -19,7 +19,7 @@ if sys.version_info[0] >= 3:
         return str(form).encode('utf-8')
 else:
     # Python 2, import modules with Python 3 names
-    from ConfigParser import ConfigParser, NoOptionError
+    import ConfigParser as configparser
     from urllib import urlencode
     from urllib2 import URLError
     from urllib2 import Request, build_opener, HTTPCookieProcessor
@@ -158,7 +158,7 @@ def get_url(cfg, option, default):
 def get_config():
     """Returns a ConfigParser object for the .kattisrc file(s)
     """
-    cfg = ConfigParser()
+    cfg = configparser.ConfigParser()
     if os.path.exists(_DEFAULT_CONFIG):
         cfg.read(_DEFAULT_CONFIG)
 
@@ -209,11 +209,11 @@ def login_from_config(cfg):
     password = token = None
     try:
         password = cfg.get('user', 'password')
-    except NoOptionError:
+    except configparser.NoOptionError:
         pass
     try:
         token = cfg.get('user', 'token')
-    except NoOptionError:
+    except configparser.NoOptionError:
         pass
     if password is None and token is None:
         raise ConfigError('''\

--- a/submit.py
+++ b/submit.py
@@ -7,20 +7,28 @@ import itertools
 import mimetypes
 import random
 import string
+
+# Python 2/3 compatibility
 if sys.version_info[0] >= 3:
-    _PYTHON_VERSION = 3
     import configparser
     import urllib.parse
     import urllib.request
     import urllib.error
+
+    def form_body(form):
+        return str(form).encode('utf-8')
 else:
     # Python 2, import modules with Python 3 names
-    _PYTHON_VERSION = 2
     import ConfigParser as configparser
     import urllib
     import urllib2
     urllib.request = urllib.error = urllib2
     urllib.parse = urllib
+
+    def form_body(form):
+        return str(form)
+
+# End Python 2/3 compatibility
 
 _DEFAULT_CONFIG = '/usr/local/etc/kattisrc'
 _VERSION = 'Version: $Version: $'
@@ -93,9 +101,7 @@ class MultiPartForm(object):
         return
 
     def make_request(self, url):
-        body = str(self)
-        if _PYTHON_VERSION == 3:
-            body = body.encode('utf-8')
+        body = form_body(self)
         request = urllib.request.Request(url, data=body)
         request.add_header('Content-type', self.get_content_type())
         request.add_header('Content-length', len(body))
@@ -152,7 +158,7 @@ def get_url(cfg, option, default):
 def get_config():
     """Returns a ConfigParser object for the .kattisrc file(s)
     """
-    cfg = configparser.ConfigParser()
+    cfg = ConfigParser()
     if os.path.exists(_DEFAULT_CONFIG):
         cfg.read(_DEFAULT_CONFIG)
 


### PR DESCRIPTION
- Locate the code handling python 2 / 3 differences in one place.
- Avoid patching imported modules.
