### PR TITLE
Created .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.kattisrc


### PR DESCRIPTION
The .gitignore includes .kattisrc to prohibit someone from accidentally commiting their token