### PR TITLE
Update _LANGUAGE_GUESS to include new languages

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -32,10 +32,10 @@ _LANGUAGE_GUESS = {
     '.cpy': 'COBOL',
     '.fs': 'F#',
     '.go': 'Go',
-    '.h': 'C++',
     '.hs': 'Haskell',
     '.java': 'Java',
-    '.js': 'JavaScript',
+    '.js': 'JavaScript (Node.js)',
+    '.ts': 'TypeScript',
     '.kt': 'Kotlin',
     '.lisp': 'Common Lisp',
     '.cl': 'Common Lisp',
@@ -44,10 +44,19 @@ _LANGUAGE_GUESS = {
     '.pas': 'Pascal',
     '.php': 'PHP',
     '.pl': 'Prolog',
+    '.py': 'Python 3',
+    '.pyc': 'Python 3',
     '.rb': 'Ruby',
     '.rs': 'Rust',
     '.scala': 'Scala',
+    '.f90': 'Fortran',
+    '.f': 'Fortran',
+    '.for': 'Fortran',
+    '.sh': 'Bash',
+    '.apl': 'APL',
+    '.ss': 'Gerbil',
 }
+
 _GUESS_MAINCLASS = {'Java', 'Scala', 'Kotlin'}
 _GUESS_MAINFILE = {'Python 2', 'Python 3', 'PHP', 'JavaScript', 'Rust', 'Pascal'}
 


### PR DESCRIPTION
In addition to adding new languages, it also does the following changes:
- removes the entry `'.h': 'C++',`
- assumes the default version of JavaScript is Node.js (it previously guessed `JavaScript`, which is an invalid language name)
- assumes the default version of python is Python3 (it previously made no guess for `.py` files)