### PR TITLE
Make `.kattisrc` lookup more robust

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -125,9 +125,14 @@ def get_config():
     if os.path.exists(_DEFAULT_CONFIG):
         cfg.read(_DEFAULT_CONFIG)
 
+    try:
+        file = __file__
+    except NameError:
+        file = sys.argv[0]
+
     if not cfg.read([os.path.join(os.path.expanduser("~"), '.kattisrc'),
-                     os.path.join(os.path.dirname(__file__), '.kattisrc'),
-                     os.path.join(os.path.dirname(os.path.realpath(__file__)), '.kattisrc')]):
+                     os.path.join(os.path.dirname(file), '.kattisrc'),
+                     os.path.join(os.path.dirname(os.path.realpath(file)), '.kattisrc')]):
         raise ConfigError('''\
 I failed to read in a config file from your home directory or from the
 same directory as this script. To download a .kattisrc file please visit

--- a/submit.py
+++ b/submit.py
@@ -126,7 +126,7 @@ def get_config():
         cfg.read(_DEFAULT_CONFIG)
 
     if not cfg.read([os.path.join(os.path.expanduser("~"), '.kattisrc'),
-                     os.path.join(os.path.dirname(sys.argv[0]), '.kattisrc'),
+                     os.path.join(os.path.dirname(__file__), '.kattisrc'),
                      os.path.join(os.path.dirname(os.path.realpath(__file__)), '.kattisrc')]):
         raise ConfigError('''\
 I failed to read in a config file from your home directory or from the

--- a/submit.py
+++ b/submit.py
@@ -126,7 +126,8 @@ def get_config():
         cfg.read(_DEFAULT_CONFIG)
 
     if not cfg.read([os.path.join(os.path.expanduser("~"), '.kattisrc'),
-                     os.path.join(os.path.dirname(sys.argv[0]), '.kattisrc')]):
+                     os.path.join(os.path.dirname(sys.argv[0]), '.kattisrc'),
+                     os.path.join(os.path.dirname(os.path.realpath(__file__)), '.kattisrc')]):
         raise ConfigError('''\
 I failed to read in a config file from your home directory or from the
 same directory as this script. To download a .kattisrc file please visit


### PR DESCRIPTION
Currently, `submit.py` does not look for `.kattisrc` correctly in some edge cases (i.e. if it is called as a symlink). This would make it consistently check the right directory in almost all cases.