### PR TITLE
Handle grouped test cases

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -368,7 +368,7 @@ def show_judgement(submission_url, cfg):
                     if 'accepted' in i: progress += color('.', _GREEN_COLOR)
                     if 'rejected' in i: progress += color('x', _RED_COLOR)
                 if status_id == _RUNNING_STATUS:
-                    progress = progress[:10*(testcases_done - 1)]+color('?', _YELLOW_COLOR)
+                    progress = progress[:10*(testcases_done - 1)] + color('?', _YELLOW_COLOR)
                 print(f'[{progress}{" " * (9*testcases_done + testcases_total - len(progress))}]  {testcases_done} / {testcases_total}', end='')
 
         sys.stdout.flush()
@@ -476,29 +476,32 @@ extension "{ext}"''')
     if not args.force:
         confirm_or_die(problem, language, files, mainclass, tag)
 
-    try:
-        result = submit(submit_url,
-                        login_reply.cookies,
-                        problem,
-                        language,
-                        files,
-                        mainclass,
-                        tag)
-    except requests.exceptions.RequestException as err:
-        print('Submit connection failed:', err)
-        sys.exit(1)
+    while True:
+        try:
+            result = submit(submit_url,
+                            login_reply.cookies,
+                            problem,
+                            language,
+                            files,
+                            mainclass,
+                            tag)
+        except requests.exceptions.RequestException as err:
+            print('Submit connection failed:', err)
+            sys.exit(1)
 
-    if result.status_code != 200:
-        print('Submission failed.')
-        if result.status_code == 403:
-            print('Access denied (403)')
-        elif result.status_code == 404:
-            print('Incorrect submit URL (404)')
-        else:
-            print('Status code:', result.status_code)
-        sys.exit(1)
+        if result.status_code != 200:
+            print('Submission failed.')
+            if result.status_code == 403:
+                print('Access denied (403)')
+            elif result.status_code == 404:
+                print('Incorrect submit URL (404)')
+            else:
+                print('Status code:', result.status_code)
+            sys.exit(1)
 
-    plain_result = result.content.decode('utf-8').replace('<br />', '\n')
+        plain_result = result.content.decode('utf-8').replace('<br />', '\n')
+        if plain_result.startswith('You are out of submission tokens.'): time.sleep(3); continue
+        break
 
     print(plain_result)
 

--- a/submit.py
+++ b/submit.py
@@ -367,6 +367,8 @@ def show_judgement(submission_url, cfg):
                     if 'is-empty' in i: break
                     if 'accepted' in i: progress += color('.', _GREEN_COLOR)
                     if 'rejected' in i: progress += color('x', _RED_COLOR)
+
+                # NB: We need to do the following math since len(color('.', _SOME_COLOR)) == 10
                 if status_id == _RUNNING_STATUS:
                     progress = progress[:10*(testcases_done - 1)] + color('?', _YELLOW_COLOR)
                 print(f'[{progress}{" " * (9*testcases_done + testcases_total - len(progress))}]  {testcases_done} / {testcases_total}', end='')
@@ -381,7 +383,7 @@ def show_judgement(submission_url, cfg):
                 root = fragment_fromstring(status['row_html'], create_parent=True)
                 cpu_time = root.xpath('.//*[@data-type="cpu"]')[0].text_content()
                 try:
-                    score = re.findall('\(([\d\.]+)\)', root.xpath('.//*[@data-type="status"]')[0].text_content())[0]
+                    score = re.findall(r'\(([\d\.]+)\)', root.xpath('.//*[@data-type="status"]')[0].text_content())[0]
                 except:
                     score = ''
                 status_text += " (" + cpu_time + ', ' + score + ")" if score else " (" + cpu_time + ")"
@@ -484,7 +486,9 @@ extension "{ext}"''')
                             language,
                             files,
                             mainclass,
-                            tag)
+                            tag,
+                            args.assignment,
+                            args.contest)
         except requests.exceptions.RequestException as err:
             print('Submit connection failed:', err)
             sys.exit(1)
@@ -500,7 +504,6 @@ extension "{ext}"''')
             sys.exit(1)
 
         plain_result = result.content.decode('utf-8').replace('<br />', '\n')
-        if plain_result.startswith('You are out of submission tokens.'): time.sleep(3); continue
         break
 
     print(plain_result)

--- a/submit.py
+++ b/submit.py
@@ -478,34 +478,31 @@ extension "{ext}"''')
     if not args.force:
         confirm_or_die(problem, language, files, mainclass, tag)
 
-    while True:
-        try:
-            result = submit(submit_url,
-                            login_reply.cookies,
-                            problem,
-                            language,
-                            files,
-                            mainclass,
-                            tag,
-                            args.assignment,
-                            args.contest)
-        except requests.exceptions.RequestException as err:
-            print('Submit connection failed:', err)
-            sys.exit(1)
+    try:
+        result = submit(submit_url,
+                        login_reply.cookies,
+                        problem,
+                        language,
+                        files,
+                        mainclass,
+                        tag,
+                        args.assignment,
+                        args.contest)
+    except requests.exceptions.RequestException as err:
+        print('Submit connection failed:', err)
+        sys.exit(1)
 
-        if result.status_code != 200:
-            print('Submission failed.')
-            if result.status_code == 403:
-                print('Access denied (403)')
-            elif result.status_code == 404:
-                print('Incorrect submit URL (404)')
-            else:
-                print('Status code:', result.status_code)
-            sys.exit(1)
+    if result.status_code != 200:
+        print('Submission failed.')
+        if result.status_code == 403:
+            print('Access denied (403)')
+        elif result.status_code == 404:
+            print('Incorrect submit URL (404)')
+        else:
+            print('Status code:', result.status_code)
+        sys.exit(1)
 
-        plain_result = result.content.decode('utf-8').replace('<br />', '\n')
-        break
-
+    plain_result = result.content.decode('utf-8').replace('<br />', '\n')
     print(plain_result)
 
     submission_url = None


### PR DESCRIPTION
# What's the problem?

Sometimes, when you're working on a question with partial scores, it is very likely that the test cases are made into groups. The current implementation hinders whether we fail the test case group(s) or not.

Here's an example I took while working on [this question](https://open.kattis.com/problems/ordla) and [this question](https://open.kattis.com/problems/sequences). Assume that `ktcli <problem_id>` is my own command alias to run the submission script along with `<problem_id>.py` attached somewhere.

Normally, if you fail a testcase, the judging will stop, as shown below.

![image](https://github.com/user-attachments/assets/cb861e77-b653-4285-a872-ca0abb1ac799)

For those with testcase groups, if you fail a testcase, instead of ending the entire judgement, there can be multiple behaviors. Usually, it will simply move on to the next testcase group, until there is none left. On other occassions, it will keep judging the next test cases anyways.

Therefore, we can't tell if we're failing a particular test case or not until we know it stops judging. In fact, we can still get partially accepted with these mistakes existing, as shown below (I did not get 100 points for this).

![image](https://github.com/user-attachments/assets/05a62a02-060e-475c-be1b-9cbe141968ab)

# So what does this PR do?

## Introduce colours (and scores too! #44)

With colours, we can finally tell these testcases apart. Here are two scenarios: when the judging is in progress, and when it's done.

### Judging in progress

Yellow question mark for a nice touch 😄

Single group (default)
![image](https://github.com/user-attachments/assets/2cb4f967-9c75-45ee-813e-71313ab314d7)

Grouped testcases
![image](https://github.com/user-attachments/assets/168d830c-8b48-45a4-bcbe-20dce3bbe608)

### AC verdict

Single group (default)
![image](https://github.com/user-attachments/assets/95d054a4-4451-4f3f-8f1c-203c304880d8)

Grouped testcases
![image](https://github.com/user-attachments/assets/4ae6bfbc-828d-4594-a967-f47a428289be)

### Non-AC verdict
![image](https://github.com/user-attachments/assets/6d0869fe-a369-44c3-9a57-343c49a72427)

## ~~Small addition: auto-retry for out-of-tokens scenario~~

~~I personally find myself too lazy to keep running the script whenever I ran out of tokens. So I made sure that the script auto-retries until it has a token again.~~

- ~~Pro: less manual work involved~~
- ~~Con: more requests sent as an attempt to submit~~

~~Here's a reference to what originally happens when you're out of tokens.~~

![image](https://github.com/user-attachments/assets/068ab1cf-626a-426e-97c6-7210956ab395)

~~This PR will ensure when the same thing happens, it will simply wait until the time is right and then does the usual behavior.~~